### PR TITLE
Build docker images by GitHub action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: 'Publish'
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Publish
+      uses: home-assistant/builder@master
+      with:
+        args: |
+          --all \
+          --target paperless-ng \
+          --docker-hub ${{ secrets.DOCKERHUB_NAMESPACE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: 'Test'
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Test build of paperless-ng
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+    - name: Test build
+      uses: home-assistant/builder@master
+      with:
+        args: |
+          --test \
+          --all \
+          --target paperless-ng \
+          --docker-hub cyclickdevelopment

--- a/paperless-ng/CHANGELOG.md
+++ b/paperless-ng/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.2.1
-- Collect paperless-ng v1.1.2
+- Collect paperless-ng v1.1.4
 
 ## 0.2
 - First release shared with [Home Assistant community](https://community.home-assistant.io/t/paperless-ng-add-on/269335)

--- a/paperless-ng/CHANGELOG.md
+++ b/paperless-ng/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.1
+- Collect paperless-ng v1.1.2
+
+## 0.2
+- First release shared with [Home Assistant community](https://community.home-assistant.io/t/paperless-ng-add-on/269335)
+
 ## 0.1.0
 
 - Initial release

--- a/paperless-ng/Dockerfile
+++ b/paperless-ng/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
     && mkdir /var/log/supervisord /var/run/supervisord
 
 # Download release of Paperless-ng
-RUN wget -O paperless.tar.xz https://github.com/jonaswinkler/paperless-ng/releases/download/ng-0.9.13/paperless-ng-0.9.13.tar.xz \
+RUN wget -O paperless.tar.xz https://github.com/jonaswinkler/paperless-ng/releases/download/ng-1.1.2/paperless-ng-1.1.2.tar.xz \
     && 7z x paperless.tar.xz \
     && 7z x paperless.tar -o/usr/src/ \
     && cd /usr/src 

--- a/paperless-ng/Dockerfile
+++ b/paperless-ng/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
     libpq-dev \
     libqpdf-dev \
     libxml2 \
+    libxml2-dev \
     libxslt1-dev \
     optipng \
     p7zip-full \
@@ -59,8 +60,8 @@ RUN cp -R ./src /usr/src/paperless/
 
 
 # Install requirements
-RUN pip3 install --upgrade supervisor setuptools \
-    && pip3 install --no-cache-dir -r requirements.txt
+RUN python3 -m pip install --upgrade pip supervisor setuptools \
+    && python3 -m pip install --no-cache-dir -r requirements.txt
 
 #### Redis Setup
 RUN apt-get install redis-server redis-tools -y
@@ -74,7 +75,7 @@ RUN apt-get -y purge build-essential libqpdf-dev \
 # copy scripts
 # FROM ORIGINAL DOCKER FILE: this fixes issues with imagemagick and PDF
 RUN cp docker/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
-RUN cp  docker/gunicorn.conf.py /usr/src/paperless
+RUN cp gunicorn.conf.py /usr/src/paperless
 RUN cp docker/supervisord.conf /etc/supervisord.conf
 # RUN cp docker/docker-entrypoint.sh /sbin/docker-entrypoint.sh
 COPY scripts/docker-entrypoint.sh /sbin/docker-entrypoint.sh

--- a/paperless-ng/Dockerfile
+++ b/paperless-ng/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update \
     imagemagick \
     jq \
     libatlas-base-dev \
+    libffi-dev \
+    libssl-dev \
     liblept5 \
     libmagic-dev \
     libpoppler-cpp-dev \
@@ -28,6 +30,7 @@ RUN apt-get update \
     pngquant \
     python3-pip \
     python3-dev \
+    python3-scipy \
     qpdf \
     sudo \
     tesseract-ocr \
@@ -44,7 +47,7 @@ RUN apt-get update \
     && mkdir /var/log/supervisord /var/run/supervisord
 
 # Download release of Paperless-ng
-RUN wget -O paperless.tar.xz https://github.com/jonaswinkler/paperless-ng/releases/download/ng-1.1.2/paperless-ng-1.1.2.tar.xz \
+RUN wget -O paperless.tar.xz https://github.com/jonaswinkler/paperless-ng/releases/download/ng-1.1.4/paperless-ng-1.1.4.tar.xz \
     && 7z x paperless.tar.xz \
     && 7z x paperless.tar -o/usr/src/ \
     && cd /usr/src 

--- a/paperless-ng/config.json
+++ b/paperless-ng/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Paperless-ng",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "slug": "paperless",
   "url": "https://github.com/jonaswinkler/paperless-ng",
   "description": "Paperless is an application that manages your personal documents. With the help of a document scanner, paperless transforms your wieldy physical document binders into a searchable archive and provides many utilities for finding and managing your documents.",

--- a/paperless-ng/config.json
+++ b/paperless-ng/config.json
@@ -4,6 +4,7 @@
   "slug": "paperless",
   "url": "https://github.com/jonaswinkler/paperless-ng",
   "description": "Paperless is an application that manages your personal documents. With the help of a document scanner, paperless transforms your wieldy physical document binders into a searchable archive and provides many utilities for finding and managing your documents.",
+  "image": "cyclickdevelopment/paperless-ng-addon-{arch}",
   "webui": "http://[HOST]:[PORT:8000]",
   "stage": "experimental",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],


### PR DESCRIPTION
Merges the `test` action and `publish` action to fix #4 

Requires three secrets to be setup:
* `DOCKERHUB_USERNAME` - username for dockerhub
* `DOCKERHUB_TOKEN` - access token for username
* `DOCKERHUB_NAMESPACE` - might be the same as username. e.g. repository at dockerhub might be `pwasher/my-image` where pwasher what I'm calling namespace. 