### PR TITLE
Allow additional OCR languages

### DIFF
--- a/paperless-ngx/CHANGELOG.md
+++ b/paperless-ngx/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.0-1
+- Expose functionality to install additional OCR languages
+
 ## 1.6.0-0
 - Swap to, and upgrade to paperless-ngx v1.6.0
 

--- a/paperless-ngx/DOCS.md
+++ b/paperless-ngx/DOCS.md
@@ -34,7 +34,8 @@ Another way is to make a copy of the `data` and `media` directories.
 filename:
   format: "{created_year}/{correspondent}/{title}"
 ocr:
-  language: eng
+  language: eng+swe
+  languages: swe
 default_superuser:
   username: admin
   email: admin@example.com
@@ -50,6 +51,14 @@ https://paperless-ngx.readthedocs.io/en/latest/advanced_usage.html#advanced-file
 Can be `eng`, `deu`, `fra`, `ita`, `spa`.
 This can be a combination of multiple languages such as deu+eng, in which case tesseract will use whatever language matches best.
 [Docs](https://paperless-ngx.readthedocs.io/en/latest/configuration.html#ocr-settings)
+
+### Option: `ocr.languages`
+
+Extra languages to install, space separated list.
+
+e.g. `swe lat`
+
+Available languages are documented in here: https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html
 
 ### Option: `default_superuser`
 

--- a/paperless-ngx/config.json
+++ b/paperless-ngx/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Paperless-ngx",
-  "version": "1.6.0-0",
+  "version": "1.6.0-1",
   "slug": "paperless",
   "url": "https://github.com/paperless-ngx/paperless-ngx",
   "description": "Paperless is an application that manages your personal documents. With the help of a document scanner, paperless transforms your wieldy physical document binders into a searchable archive and provides many utilities for finding and managing your documents.",
@@ -22,7 +22,8 @@
       "format": "{created_year}/{correspondent}/{title}"
     },
     "ocr": {
-      "language": "eng"
+      "language": "eng",
+      "languages": null
     },
     "default_superuser": {
       "username": null,
@@ -35,7 +36,8 @@
       "format": "str"
     },
     "ocr": {
-      "language": "str"
+      "language": "str",
+      "languages": "str?"
     },
     "default_superuser": {
       "username": "str",

--- a/paperless-ngx/scripts/docker-entrypoint.sh
+++ b/paperless-ngx/scripts/docker-entrypoint.sh
@@ -12,6 +12,7 @@ echo "Entry script"
 # Load config
 export PAPERLESS_FILENAME_FORMAT=$(jq --raw-output ".filename.format" $CONFIG_PATH)
 export PAPERLESS_OCR_LANGUAGE=$(jq --raw-output ".ocr.language" $CONFIG_PATH)
+export PAPERLESS_OCR_LANGUAGES=$(jq --raw-output ".ocr.languages" $CONFIG_PATH)
 
 export DEFAULT_USERNAME=$(jq --raw-output ".default_superuser.username" $CONFIG_PATH)
 export DEFAULT_EMAIL=$(jq --raw-output ".default_superuser.email" $CONFIG_PATH)


### PR DESCRIPTION
This change allows the use of more languages in the OCR step

The logic to install the extra languages was already present, but the configuration was not exposed